### PR TITLE
Fix install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/stleary/JSON-java
 [submodule "third_party/SharpGen"]
 	path = third_party/SharpGen
-	url = https://github.com/cobbr/SharpGen
+	url = https://github.com/cobbr/SharpGen.git

--- a/third_party/SharpGen
+++ b/third_party/SharpGen
@@ -1,1 +1,0 @@
-/share/tools/development/SharpGen


### PR DESCRIPTION
Hello!
First of all, thank you for your amazing work, combining cobalt strike with python sounds insanely powerful.

This is a fix to the installation issue described here: https://github.com/cobbr/SharpGen/issues/6

To install, as described in the readme, just run:
```bash
sudo python3 setup.py install
```
At the end we can see that it installs properly:
```
Installed /usr/lib/python3.9/site-packages/pycobalt-1.2.0-py3.9.egg
Processing dependencies for pycobalt==1.2.0
Finished processing dependencies for pycobalt==1.2.0
```
I ran the 'example-alias' command and it seems to be working fine.
```
beacon> example-alias
[*] example alias
```
